### PR TITLE
Issue #6: Reduce duplicate API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ Use these commands in rules, dashboards, or device pages:
 ## 🔧 Configuration Options
 
 ### Device Preferences
-- **Auto Refresh** - How often to update (1-60 minutes)
 - **Debug Logging** - Enable for troubleshooting
 - **Description Logging** - Enable status messages
 
 ### App Settings
+- **Refresh Interval** - How often to update thermostat data (1-60 minutes, default 5)
 - **API Credentials** - Consumer Key and Secret from Resideo
 - **OAuth Authentication** - Secure connection to Resideo API
 - **Device Discovery** - Automatically find your thermostats
@@ -201,6 +201,7 @@ if (presence is "not present") {
 
 ## 📈 Version History
 
+- **v1.5.0** - Reduce API calls - centralized refresh scheduling in app with debouncing, configurable refresh interval
 - **v1.4.x** - Celsius/Fahrenheit support - temperatures automatically display in thermostat's native unit with proper precision (integers for °F, 0.5° increments for °C)
 - **v1.3.0** - Dynamic capability detection - supportedThermostatModes now reflects actual thermostat capabilities (emergency heat only shown for thermostats that support it)
 - **v1.2.9** - Fix supported modes - use JSON format for JSON_OBJECT attributes

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,10 +1,10 @@
 {
     "packageName": "Hubitat Resideo T10 Integration",
     "author": "Mathew Beall",
-    "version": "1.4.4",
+    "version": "1.5.0",
     "minimumHEVersion": "2.2.4",
     "dateReleased": "2026-01-18",
-    "releaseNotes": "Use BigDecimal to force Celsius decimal display (17.0 not 17)",
+    "releaseNotes": "Reduce API calls - centralized refresh scheduling with debouncing, configurable refresh interval in app settings",
     "documentationLink": "https://github.com/mathewbeall/hubitat-resideo_T10-integration/blob/main/README.md",
     "communityLink": "https://github.com/mathewbeall/hubitat-resideo_T10-integration",
     "apps": [


### PR DESCRIPTION
## Summary
- Centralized refresh scheduling in app (removes per-device scheduling from driver)
- Added configurable refresh interval in app settings (1-60 minutes, default 5)
- Added `requestRefresh()` with debouncing to coalesce rapid refresh requests into single API call
- Commands now use cached thermostat data (60s freshness threshold) instead of fetching before every command

## Before/After
- **Before**: 2 thermostats = 5+ API calls per refresh cycle
- **After**: 2 thermostats = 1 API call per cycle (+1 after commands)

## Test plan
- [ ] Verify single "Discovered X thermostats" log entry per refresh cycle
- [ ] Verify configurable refresh interval works in app settings
- [ ] Verify manual refresh from device page still works (debounced)
- [ ] Verify commands still work correctly with cached data
- [ ] Verify data refreshes after sending commands

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)