### PR TITLE
Issue #8: Fix Fahrenheit down button rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ if (presence is "not present") {
 
 ## 📈 Version History
 
+- **v1.5.1** - Fix Fahrenheit down button - dashboard 0.5 increments now round in correct direction (Issue #8)
 - **v1.5.0** - Reduce API calls - centralized refresh scheduling in app with debouncing, configurable refresh interval
 - **v1.4.x** - Celsius/Fahrenheit support - temperatures automatically display in thermostat's native unit with proper precision (integers for °F, 0.5° increments for °C)
 - **v1.3.0** - Dynamic capability detection - supportedThermostatModes now reflects actual thermostat capabilities (emergency heat only shown for thermostats that support it)

--- a/hubitat-resideo-driver.groovy
+++ b/hubitat-resideo-driver.groovy
@@ -240,8 +240,16 @@ def setHeatingSetpoint(temperature) {
     def nativeUnit = getNativeUnit()
     if (debugOutput) log.debug "Setting heating setpoint to ${temperature}°${nativeUnit}"
 
-    // Round appropriately: 0.5 for Celsius (with decimal), integer for Fahrenheit
-    def nativeTemp = formatTemperature(temperature, nativeUnit)
+    // Round appropriately: 0.5 for Celsius, integer for Fahrenheit
+    // For Fahrenheit, round in the direction of change to fix dashboard 0.5 increment issue
+    def nativeTemp
+    if (nativeUnit == "F") {
+        def currentSetpoint = device.currentValue("heatingSetpoint")
+        nativeTemp = (currentSetpoint != null && temperature < currentSetpoint) ?
+            Math.floor(temperature) as Integer : Math.ceil(temperature) as Integer
+    } else {
+        nativeTemp = formatTemperature(temperature, nativeUnit)
+    }
 
     def result = parent.sendThermostatCommand(device.deviceNetworkId, "setTemperature", [
         heatSetpoint: nativeTemp
@@ -259,8 +267,16 @@ def setCoolingSetpoint(temperature) {
     def nativeUnit = getNativeUnit()
     if (debugOutput) log.debug "Setting cooling setpoint to ${temperature}°${nativeUnit}"
 
-    // Round appropriately: 0.5 for Celsius (with decimal), integer for Fahrenheit
-    def nativeTemp = formatTemperature(temperature, nativeUnit)
+    // Round appropriately: 0.5 for Celsius, integer for Fahrenheit
+    // For Fahrenheit, round in the direction of change to fix dashboard 0.5 increment issue
+    def nativeTemp
+    if (nativeUnit == "F") {
+        def currentSetpoint = device.currentValue("coolingSetpoint")
+        nativeTemp = (currentSetpoint != null && temperature < currentSetpoint) ?
+            Math.floor(temperature) as Integer : Math.ceil(temperature) as Integer
+    } else {
+        nativeTemp = formatTemperature(temperature, nativeUnit)
+    }
 
     def result = parent.sendThermostatCommand(device.deviceNetworkId, "setTemperature", [
         coolSetpoint: nativeTemp

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,10 +1,10 @@
 {
     "packageName": "Hubitat Resideo T10 Integration",
     "author": "Mathew Beall",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "minimumHEVersion": "2.2.4",
     "dateReleased": "2026-01-18",
-    "releaseNotes": "Reduce API calls - centralized refresh scheduling with debouncing, configurable refresh interval in app settings",
+    "releaseNotes": "Fix Fahrenheit down button - dashboard 0.5 increments now round in correct direction",
     "documentationLink": "https://github.com/mathewbeall/hubitat-resideo_T10-integration/blob/main/README.md",
     "communityLink": "https://github.com/mathewbeall/hubitat-resideo_T10-integration",
     "apps": [


### PR DESCRIPTION
## Summary
- Fix dashboard down button not working in Fahrenheit mode
- Dashboard sends 0.5 degree increments; `Math.round(65.5)` was rounding back to 66
- Now uses direction-aware rounding: floor when decreasing, ceil when increasing

## Changes
- `setHeatingSetpoint()` and `setCoolingSetpoint()` now detect direction of change
- Fahrenheit mode uses `Math.floor()` for down, `Math.ceil()` for up
- Celsius mode unchanged (already handles 0.5 increments correctly)

## Test plan
- [ ] Set thermostat to Fahrenheit mode at 68°F
- [ ] Tap down arrow on dashboard - should go to 67°F (not stay at 68)
- [ ] Tap up arrow on dashboard - should go to 68°F
- [ ] Verify Celsius mode still works with 0.5° increments

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)