### PR TITLE
Fix duplicate discovery cycles on refresh (Issue #10)

### DIFF
--- a/hubitat-resideo-app.groovy
+++ b/hubitat-resideo-app.groovy
@@ -741,6 +741,15 @@ def executeRefresh() {
 }
 
 def updateAllDevices() {
+    // Prevent duplicate refreshes within 5 seconds (Issue #10)
+    // This can happen when scheduled refresh and driver refresh overlap
+    def timeSinceLastRefresh = state.lastRefresh ? (now() - state.lastRefresh) : Long.MAX_VALUE
+    if (timeSinceLastRefresh < 5000) {
+        logDebug "Skipping duplicate refresh - last refresh was ${timeSinceLastRefresh}ms ago"
+        state.refreshPending = false
+        return
+    }
+
     if (debugOutput) logDebug "Updating all thermostat devices"
 
     discoverThermostats() // Refresh data from API


### PR DESCRIPTION
## Summary
- Adds timestamp-based guard to `updateAllDevices()` that skips execution if a refresh occurred within the last 5 seconds
- Fixes overlap between scheduled refresh and driver refresh requests that caused duplicate API calls

## Root Cause
The `updateAllDevices()` function was being called from two independent paths:
1. Directly from the scheduled cron job
2. Through `requestRefresh()` → `executeRefresh()` (2 second delay)

When these paths overlapped, discovery ran twice ~2 seconds apart.

## Test plan
- [ ] Install updated app on Hubitat
- [ ] Trigger manual refresh while waiting for scheduled refresh
- [ ] Verify only one "Discovered X thermostats" message appears in logs
- [ ] Verify duplicate refresh shows "Skipping duplicate refresh" debug message

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)