### PR TITLE
Issue #14: Add remote sensors as child devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ if (presence is "not present") {
 
 ## 📈 Version History
 
+- **v1.6.0** - Add remote sensors as child devices - T10 room sensors now appear as individual Hubitat devices with temperature, humidity, motion, and occupancy reporting (Issue #14)
 - **v1.5.3** - Fix broken API connectivity - migrate from expired api.honeywell.com to api.honeywellhome.com (Issue #12)
 - **v1.5.2** - Fix duplicate discovery cycles - prevent double API calls when scheduled and manual refresh overlap (Issue #10)
 - **v1.5.1** - Fix Fahrenheit down button - dashboard 0.5 increments now round in correct direction (Issue #8)

--- a/hubitat-resideo-app.groovy
+++ b/hubitat-resideo-app.groovy
@@ -708,6 +708,7 @@ def installThermostat(thermostat) {
 
         // Initial update
         updateThermostat(childDevice, thermostat)
+        discoverAndInstallSensors(thermostat)
 
         return true  // Installation successful
 
@@ -715,6 +716,54 @@ def installThermostat(thermostat) {
         log.error "Error installing thermostat ${name}: ${e.message}"
         return false  // Installation failed
     }
+}
+
+def discoverAndInstallSensors(thermostat) {
+    def deviceId = thermostat.deviceID
+    def locationId = thermostat.locationID
+    def nativeUnit = thermostat.units?.startsWith("C") ? "C" : "F"
+
+    def roomData = getRoomData(deviceId, locationId)
+    if (!roomData?.rooms) return
+
+    roomData.rooms.each { room ->
+        room.accessories?.each { accessory ->
+            def attr = accessory.accessoryAttribute
+            def val = accessory.accessoryValue
+            if (!attr || attr.type == "Thermostat") return
+
+            def serialNumber = attr.serialNumber
+            def dni = "${deviceId}-sensor-${serialNumber}"
+            def sensorName = "${room.name} Sensor"
+
+            def childDevice = getChildDevice(dni)
+            if (!childDevice) {
+                log.info "Creating remote sensor child: ${sensorName} (${dni})"
+                childDevice = addChildDevice("mathewbeall", "Resideo Remote Sensor", dni, null,
+                    [name: sensorName, label: sensorName, isComponent: false])
+            }
+
+            updateSensor(childDevice, room, accessory, nativeUnit)
+        }
+    }
+}
+
+def updateSensor(device, room, accessory, nativeUnit) {
+    def attr = accessory.accessoryAttribute
+    def val = accessory.accessoryValue
+    if (!val) return
+
+    device.updateSensorData([
+        roomName         : room.name,
+        nativeUnit       : nativeUnit,
+        indoorTemperature: val.indoorTemperature,
+        indoorHumidity   : val.indoorHumidity,
+        motionDet        : val.motionDet,
+        occupancyDet     : val.occupancyDet,
+        batteryStatus    : val.batteryStatus,
+        rssiAverage      : val.rssiAverage,
+        sensorType       : attr.type
+    ])
 }
 
 /**
@@ -757,6 +806,10 @@ def updateAllDevices() {
 
     getChildDevices().each { device ->
         def deviceId = device.deviceNetworkId
+
+        // Skip sensor child devices - they are updated separately below
+        if (deviceId.contains("-sensor-")) return
+
         def thermostat = state.thermostats?.find { it.deviceID == deviceId }
 
         if (thermostat) {
@@ -764,6 +817,11 @@ def updateAllDevices() {
         } else {
             log.warn "Could not find thermostat data for device: ${device.displayName}"
         }
+    }
+
+    // Update remote sensor children for each thermostat
+    state.thermostats?.each { thermostat ->
+        discoverAndInstallSensors(thermostat)
     }
 }
 

--- a/hubitat-resideo-app.groovy
+++ b/hubitat-resideo-app.groovy
@@ -738,9 +738,14 @@ def discoverAndInstallSensors(thermostat) {
 
             def childDevice = getChildDevice(dni)
             if (!childDevice) {
-                log.info "Creating remote sensor child: ${sensorName} (${dni})"
-                childDevice = addChildDevice("mathewbeall", "Resideo Remote Sensor", dni, null,
-                    [name: sensorName, label: sensorName, isComponent: false])
+                try {
+                    log.info "Creating remote sensor child: ${sensorName} (${dni})"
+                    childDevice = addChildDevice("mathewbeall", "Resideo Remote Sensor", dni, null,
+                        [name: sensorName, label: sensorName, isComponent: false])
+                } catch (Exception e) {
+                    log.warn "Could not create sensor child device '${sensorName}' — is the 'Resideo Remote Sensor' driver installed? (${e.message})"
+                    return
+                }
             }
 
             updateSensor(childDevice, room, accessory, nativeUnit)

--- a/hubitat-resideo-sensor-driver.groovy
+++ b/hubitat-resideo-sensor-driver.groovy
@@ -1,0 +1,174 @@
+/**
+ *  Resideo Remote Sensor Driver
+ *
+ *  Copyright 2024 Mathew Beall
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ */
+
+metadata {
+    definition (
+        name: "Resideo Remote Sensor",
+        namespace: "mathewbeall",
+        author: "Mathew Beall",
+        importUrl: ""
+    ) {
+        capability "TemperatureMeasurement"
+        capability "RelativeHumidityMeasurement"
+        capability "MotionSensor"
+        capability "Sensor"
+        capability "Refresh"
+
+        attribute "humidity", "number"
+        attribute "occupancy", "string"
+        attribute "battery", "string"
+        attribute "rssi", "number"
+        attribute "roomName", "string"
+        attribute "lastUpdate", "string"
+        attribute "sensorType", "string"
+
+        command "refresh"
+    }
+
+    preferences {
+        input "debugOutput", "bool", title: "Enable debug logging", defaultValue: false
+        input "descTextEnable", "bool", title: "Enable descriptionText logging", defaultValue: true
+    }
+}
+
+def installed() {
+    if (debugOutput) log.debug "Installing Resideo Remote Sensor: ${device.displayName}"
+    initialize()
+}
+
+def updated() {
+    if (debugOutput) log.debug "Updated Resideo Remote Sensor: ${device.displayName}"
+
+    // Auto-disable debug logging after 30 minutes
+    if (debugOutput) {
+        runIn(1800, logsOff)
+    }
+
+    initialize()
+}
+
+def initialize() {
+    // Initial data will be loaded by parent app's updateAllDevices()
+}
+
+def refresh() {
+    if (debugOutput) log.debug "Refreshing sensor data for ${device.displayName}"
+    parent.requestRefresh()
+}
+
+def updateSensorData(Map sensorData) {
+    if (debugOutput) log.debug "Updating sensor data: ${sensorData}"
+
+    try {
+        def nativeUnit = sensorData.nativeUnit ?: "F"
+
+        // Room name
+        if (sensorData.roomName) {
+            sendEvent(name: "roomName", value: sensorData.roomName)
+        }
+
+        // Temperature
+        def temperature = sensorData.indoorTemperature
+        if (temperature != null) {
+            def temp = formatTemperature(temperature, nativeUnit)
+            sendEvent(name: "temperature", value: temp, unit: "°${nativeUnit}")
+            if (descTextEnable) log.info "${device.displayName} temperature is ${temp}°${nativeUnit}"
+        }
+
+        // Humidity
+        def humidity = sensorData.indoorHumidity
+        if (humidity != null) {
+            sendEvent(name: "humidity", value: humidity, unit: "%")
+            if (descTextEnable) log.info "${device.displayName} humidity is ${humidity}%"
+        }
+
+        // Motion
+        def motionDet = sensorData.motionDet
+        if (motionDet != null) {
+            def motionValue = motionDet ? "active" : "inactive"
+            sendEvent(name: "motion", value: motionValue)
+            if (descTextEnable) log.info "${device.displayName} motion is ${motionValue}"
+        }
+
+        // Occupancy
+        def occupancyDet = sensorData.occupancyDet
+        if (occupancyDet != null) {
+            def occupancyValue = occupancyDet ? "occupied" : "unoccupied"
+            sendEvent(name: "occupancy", value: occupancyValue)
+            if (descTextEnable) log.info "${device.displayName} occupancy is ${occupancyValue}"
+        }
+
+        // Battery status
+        def batteryStatus = sensorData.batteryStatus
+        if (batteryStatus != null) {
+            sendEvent(name: "battery", value: batteryStatus)
+        }
+
+        // RSSI
+        def rssiAverage = sensorData.rssiAverage
+        if (rssiAverage != null) {
+            sendEvent(name: "rssi", value: rssiAverage)
+        }
+
+        // Sensor type
+        def sensorType = sensorData.sensorType
+        if (sensorType) {
+            sendEvent(name: "sensorType", value: sensorType)
+        }
+
+        // Last update timestamp
+        sendEvent(name: "lastUpdate", value: new Date().format("yyyy-MM-dd HH:mm:ss"))
+
+    } catch (Exception e) {
+        log.error "Error updating sensor data: ${e.message}"
+    }
+}
+
+// ========== Temperature Conversion ==========
+
+/**
+ * Format temperature with proper precision for the unit
+ * Fahrenheit: integer (no decimals)
+ * Celsius: 0.5 degree precision (always shows decimal, e.g., 17.0, 17.5)
+ */
+private formatTemperature(value, unit) {
+    if (value == null) return null
+    if (unit == "C") {
+        // Round to 0.5 and use BigDecimal with scale 1 to always show one decimal
+        def rounded = Math.round(value * 2) / 2.0
+        return new BigDecimal(rounded).setScale(1, BigDecimal.ROUND_HALF_UP)
+    } else {
+        return Math.round(value) as Integer
+    }
+}
+
+// ========== Logging Functions ==========
+
+def logsOff() {
+    log.warn "Debug logging disabled for ${device.displayName}"
+    device.updateSetting("debugOutput", [value: "false", type: "bool"])
+}
+
+private logDebug(msg) {
+    if (settings?.debugOutput || settings?.debugOutput == null) {
+        log.debug "$msg"
+    }
+}
+
+private logInfo(msg) {
+    if (settings?.descTextEnable || settings?.descTextEnable == null) {
+        log.info "$msg"
+    }
+}

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,10 +1,10 @@
 {
     "packageName": "Hubitat Resideo T10 Integration",
     "author": "Mathew Beall",
-    "version": "1.5.3",
+    "version": "1.6.0",
     "minimumHEVersion": "2.2.4",
-    "dateReleased": "2026-05-23",
-    "releaseNotes": "Fix broken API connectivity - migrate from expired api.honeywell.com to api.honeywellhome.com (Issue #12)",
+    "dateReleased": "2026-07-05",
+    "releaseNotes": "Add remote sensors as child devices (Issue #14) - T10 room sensors now appear as individual Hubitat devices with temperature, humidity, motion, and occupancy reporting",
     "documentationLink": "https://github.com/mathewbeall/hubitat-resideo_T10-integration/blob/main/README.md",
     "communityLink": "https://github.com/mathewbeall/hubitat-resideo_T10-integration",
     "apps": [
@@ -25,6 +25,13 @@
             "namespace": "mathewbeall",
             "location": "https://raw.githubusercontent.com/mathewbeall/hubitat-resideo_T10-integration/main/hubitat-resideo-driver.groovy",
             "required": true
+        },
+        {
+            "id": "resideo-remote-sensor",
+            "name": "Resideo Remote Sensor",
+            "namespace": "mathewbeall",
+            "location": "https://raw.githubusercontent.com/mathewbeall/hubitat-resideo_T10-integration/main/hubitat-resideo-sensor-driver.groovy",
+            "required": false
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds a new `hubitat-resideo-sensor-driver.groovy` driver for T10 remote room sensors (S-Series accessories)
- Remote sensors are discovered automatically via the existing rooms API (`/v2/devices/thermostats/{id}/group/{groupId}/rooms`) and created as Hubitat child devices
- Each sensor is updated on every refresh cycle alongside the thermostat
- Bumps package version to **1.6.0** in `packageManifest.json`

## New sensor child device capabilities

- `TemperatureMeasurement` — room temperature (respects F/C unit from parent thermostat)
- `RelativeHumidityMeasurement` — room humidity
- `MotionSensor` — motion active/inactive
- Custom attributes: `occupancy`, `battery` (string: "OK"/"Low"), `rssi`, `roomName`, `sensorType`, `lastUpdate`

## How it works

- Child device DNI format: `{thermostatDeviceId}-sensor-{sensorSerialNumber}` (deterministic, collision-free)
- Built-in thermostat sensor (type `"Thermostat"`) is skipped; only external accessories (e.g., `"IndoorAirSensor"`) become child devices
- `discoverAndInstallSensors()` runs on initial install and every refresh — safe to call repeatedly (idempotent)
- Sensor driver is `required: false` in HPM so existing users aren't forced to install it

## Test plan

- [ ] Install the new sensor driver in Hubitat
- [ ] Run "Discover Devices" in the Resideo app — remote sensors should appear as new child devices
- [ ] Verify temperature, humidity, motion, and occupancy attributes populate correctly
- [ ] Confirm existing thermostat devices continue to work normally
- [ ] Verify refresh cycle updates sensor data without errors in Hubitat logs

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)